### PR TITLE
Use 'creates' option

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -114,7 +114,7 @@
 - name: Install Perl
   sudo: "{{ ansible_user_id == 'root' ? 'yes' : 'no' }}"
   sudo_user: '{{ perlbrew_user }}'
-  shell: "{{ perlbrew_bin }} install --verbose {{ perl_version }} # creates='{{ perlbrew_root }}/perls/{{ perl_version }}'"
+  shell: "{{ perlbrew_bin }} install --verbose {{ perl_version }} creates='{{ perlbrew_root }}/perls/{{ perl_version }}'"
   register: perlbrew_build_output
   environment:
     http_proxy: http_proxy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,7 +68,7 @@
   lineinfile: dest='{{ item.dest }}' line='{{ item.line }}'
   with_items:
   - { dest: '~{{ perlbrew_user }}/.profile', line: 'export PERLBREW_ROOT={{ perlbrew_root }}' }
-  - { dest: '~{{ perlbrew_user }}/.profile', line: 'source {{ perlbrew_root }}/etc/bashrc' }
+  - { dest: '~{{ perlbrew_user }}/.profile', line: 'source ${PERLBREW_ROOT}/etc/bashrc' }
   when: use_profile and switch_to_new_perl
   tags: [ perlbrew, profile ]
 
@@ -78,7 +78,7 @@
   lineinfile: dest='{{ item.dest }}' line='{{ item.line }}'
   with_items:
   - { dest: '~{{ perlbrew_user }}/.profile', line: '#export PERLBREW_ROOT={{ perlbrew_root }}' }
-  - { dest: '~{{ perlbrew_user }}/.profile', line: '#source {{ perlbrew_root }}/etc/bashrc' }
+  - { dest: '~{{ perlbrew_user }}/.profile', line: '#source ${PERLBREW_ROOT}/etc/bashrc' }
   when: use_profile and not switch_to_new_perl
   tags: [ perlbrew, profile ]
 
@@ -95,8 +95,8 @@
   lineinfile: dest='{{ item.dest }}' line='{{ item.line }}'
   with_items:
   - { dest: '~{{ perlbrew_user }}/.bashrc', line: 'export PERLBREW_ROOT={{ perlbrew_root }}' }
-  - { dest: '~{{ perlbrew_user }}/.bashrc', line: '. {{ perlbrew_root }}/etc/bashrc' }
-  - { dest: '~{{ perlbrew_user }}/.bashrc', line: '. {{ perlbrew_root }}/etc/perlbrew-completion.bash' }
+  - { dest: '~{{ perlbrew_user }}/.bashrc', line: '. ${PERLBREW_ROOT}/etc/bashrc' }
+  - { dest: '~{{ perlbrew_user }}/.bashrc', line: '. ${PERLBREW_ROOT}/etc/perlbrew-completion.bash' }
   when: switch_to_new_perl and not use_profile
   tags: [ perlbrew, bashrc ]
 
@@ -106,8 +106,8 @@
   lineinfile: dest='{{ item.dest }}' line='{{ item.line }}'
   with_items:
   - { dest: '~{{ perlbrew_user }}/.bashrc', line: '#export PERLBREW_ROOT={{ perlbrew_root }}' }
-  - { dest: '~{{ perlbrew_user }}/.bashrc', line: '#. {{ perlbrew_root }}/etc/bashrc' }
-  - { dest: '~{{ perlbrew_user }}/.bashrc', line: '#. {{ perlbrew_root }}/etc/perlbrew-completion.bash' }
+  - { dest: '~{{ perlbrew_user }}/.bashrc', line: '#. ${PERLBREW_ROOT}/etc/bashrc' }
+  - { dest: '~{{ perlbrew_user }}/.bashrc', line: '#. ${PERLBREW_ROOT}/etc/perlbrew-completion.bash' }
   when: not switch_to_new_perl and not use_profile
   tags: [ perlbrew, bashrc ]
 


### PR DESCRIPTION
Is there a reason for the hash before `creates` in line 117? I saw in a previous issue that @marcusramberg didn't intended to push that change (ccdb78e830974cfad12799af2232a69481605a6f).